### PR TITLE
fix: check if terminal instance is tty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,4 +35,6 @@ process.stdin.on('keypress', function (ch, key) {
     }
 });
 
-process.stdin.setRawMode(true);
+if (process.stdout.isTTY){
+    process.stdin.setRawMode(true)
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -35,6 +35,5 @@ process.stdin.on('keypress', function (ch, key) {
     }
 });
 
-if (process.stdout.isTTY){
+if (process.stdout.isTTY)
     process.stdin.setRawMode(true)
-}


### PR DESCRIPTION
When Node.js detects that it is being run inside a TTY context, then process.stdin will be a tty.ReadStream instance and process.stdout will be a tty.WriteStream instance. The preferred way to check if Node.js is being run in a TTY context is to check process.stdout.isTTY: