### PR TITLE
[WIP] fix unhandled promise rejection during start with testcafe versions > 0.21.1

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -21,31 +21,29 @@ class Controller extends EventEmitter {
     }
 
     init (tcArguments) {
-        this._initFileWatching(tcArguments.src);
+        this._initFileWatching(tcArguments.resolvedFiles);
 
         this.testRunner = new TestRunner(tcArguments, logger);
 
         this.testRunner.on(this.testRunner.TEST_RUN_STARTED, () => logger.testsStarted());
 
         this.testRunner.on(this.testRunner.TEST_RUN_DONE_EVENT, e => {
-            if (!this.restarting)
-                logger.testsFinished();
-
             this.running = false;
-
-            if (e.err)
+            if (!this.restarting) {
+                logger.testsFinished();
+            }
+            if (e.err) {
                 console.log(`ERROR: ${e.err}`);
+            }
         });
 
         this.testRunner.on(this.testRunner.REQUIRED_MODULE_FOUND_EVENT, e => {
             this.emit(this.REQUIRED_MODULE_FOUND_EVENT, e);
         });
 
-        this.testRunner.init()
-            .then(() => {
-                logger.intro();
-                this._runTests();
-            });
+        return this.testRunner.init()
+            .then(() => logger.intro(tcArguments))
+            .then(() => this._runTests());
     }
 
     _initFileWatching (src) {
@@ -53,24 +51,17 @@ class Controller extends EventEmitter {
 
         this.on(this.REQUIRED_MODULE_FOUND_EVENT, e => fileWatcher.addFile(e.filename));
 
-        fileWatcher.on(fileWatcher.FILE_CHANGED_EVENT, () => {
-            if (!this.watchingPaused)
-                this._sourcesChanged();
-        });
-    }
-
-    _sourcesChanged () {
-        if (this.running)
-            return;
-
-        this._runTests(true);
+        fileWatcher.on(fileWatcher.FILE_CHANGED_EVENT, () => this._runTests(true));
     }
 
     _runTests (sourceChanged) {
-        logger.runTests(sourceChanged);
-
+        if (this.watchingPaused || this.running) {
+            return;
+        }
         this.running = true;
-        this.testRunner.run();
+        this.restarting = false;
+        logger.runTests(sourceChanged);
+        return this.testRunner.run();
     }
 
     toggleWatching () {
@@ -90,28 +81,24 @@ class Controller extends EventEmitter {
 
         return this.testRunner.stop()
             .then(() => {
+                this.restarting = false;
                 this.running = false;
             });
     }
 
     restart () {
-        if (this.restarting)
-            return;
-
-        if (!this.running)
-            this._runTests();
-        else {
-            this.restarting = true;
-
-            this.stop().then(() => {
-                logger.testsFinished();
-
-                this.restarting = false;
-                this.running    = false;
-
-                this._runTests();
-            });
+        if (this.restarting) {
+            return Promise.resolve();
         }
+        this.restarting = true;
+        if (this.running) {
+            return this.stop()
+                .then(() => logger.testsFinished())
+                .then(() => this._runTests());
+        }
+
+        return this._runTests();   
+        
     }
 
     exit () {

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const CLIArgumentParser = require('testcafe/lib/cli/argument-parser');
 const exitHook          = require('async-exit-hook');
 const keypress          = require('keypress');
 const controller        = require('./controller');
+const globby = require('globby');
 
 const tcArguments = new CLIArgumentParser();
 
@@ -13,6 +14,8 @@ exitHook(cb => {
 });
 
 tcArguments.parse(process.argv)
+    .then(() => globby(tcArguments.src))
+    .then((resolvedFiles) => tcArguments.resolvedFiles = resolvedFiles)
     .then(() => controller.init(tcArguments));
 
 
@@ -22,18 +25,19 @@ keypress(process.stdin);
 process.stdin.on('keypress', function (ch, key) {
     if (key && key.ctrl) {
         if (key.name === 's')
-            controller.stop();
+            return controller.stop();
 
         else if (key.name === 'r')
-            controller.restart();
+            return controller.restart();
 
         else if (key.name === 'c')
-            controller.exit().then(() => process.exit(0));
+            return controller.exit().then(() => process.exit(0));
 
         else if (key.name === 'w')
-            controller.toggleWatching();
+            return controller.toggleWatching();
     }
 });
 
-if (process.stdout.isTTY)
-    process.stdin.setRawMode(true)
+if (process.stdout.isTTY) {
+    process.stdin.setRawMode(true);
+}

--- a/lib/logger/base.js
+++ b/lib/logger/base.js
@@ -51,8 +51,13 @@ You can use the following keys in the terminal:
         throw new Error('Not implemented');
     }
 
-    intro () {
+    intro (tcArguments) {
         this._write(this.MESSAGES.intro);
+        if (tcArguments && Array.isArray(tcArguments.resolvedFiles)) {
+            this._status('Watching files:');
+            tcArguments.resolvedFiles.forEach((file) => this._write('  ' + file + '\n'));
+            this._write('\n');
+        }
     }
 
     runTests (sourcesChanged) {

--- a/lib/test-run-controller.js
+++ b/lib/test-run-controller.js
@@ -126,6 +126,7 @@ module.exports = class TestRunController extends EventEmitter {
     }
 
     _onTestRunCreated (testRun) {
+        this.testWrappers = [];
         const test = testRun[liveTestRunStorage].test;
 
         let testWrapper = this._getTestWrapper(test);
@@ -198,8 +199,6 @@ module.exports = class TestRunController extends EventEmitter {
                     pendingRunsResolvers.push(testRunWrapper.finish);
             });
         });
-
-        this.testWrappers = [];
 
         pendingRunsResolvers.forEach(r => r());
     }

--- a/lib/test-runner.js
+++ b/lib/test-runner.js
@@ -30,7 +30,7 @@ module.exports = class TestRunner extends EventEmitter {
         this.remoteCount = tcArguments.remoteCount;
         this.concurrency = tcArguments.concurrency || 1;
         this.browsers    = tcArguments.browsers;
-        this.src         = tcArguments.src;
+        this.src         = tcArguments.resolvedFiles;
         this.filter      = tcArguments.filter;
 
         this.reporters = this.opts.reporters.map(r => {
@@ -80,8 +80,9 @@ module.exports = class TestRunner extends EventEmitter {
     }
 
     _onTestFinished () {
-        if (--this.activeTestCount)
-            this._resolveAllTestRunPromises();
+        if (--this.activeTestCount) {
+            return this._resolveAllTestRunPromises();
+        }
     }
 
     _handleTestRunCommand () {
@@ -202,7 +203,7 @@ module.exports = class TestRunner extends EventEmitter {
             ._getTests()
             .then(tests => {
                 runnableConf.tests = tests;
-
+           
                 this.testRunController.run(tests.filter(t => !t.skip).length);
                 this.tcRunnerTaskPromise = tcRunner.run(this.opts);
 
@@ -236,15 +237,12 @@ module.exports = class TestRunner extends EventEmitter {
                 ._runTests(this.tcRunner, this.runnableConf)
                 .catch(err => {
                     runError = err;
-                });
+                }); 
         }
 
-        testRunPromise
+        return testRunPromise
             .then(() => {
                 this.tcRunnerTaskPromise = null;
-
-                if (this.stopping)
-                    return;
 
                 this.emit(this.TEST_RUN_DONE_EVENT, { err: runError });
             });

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "ansi-escapes": "^3.0.0",
     "async-exit-hook": "^2.0.1",
+    "globby": "^8.0.1",
     "graphlib": "^2.1.5",
     "keypress": "^0.2.1",
     "log-update-async-hook": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-live",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "A watcher utility for TestCafe. Watches for changes in test files and automatically runs tests when these changes occur.",
   "main": "lib/index.js",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "testcafe-live",
-  "version": "0.1.5",
+  "version": "0.1.4",
   "description": "A watcher utility for TestCafe. Watches for changes in test files and automatically runs tests when these changes occur.",
   "main": "lib/index.js",
   "bin": {


### PR DESCRIPTION
The goal of this PR is to solve issue #25 

**The problem:**

`testcafe-live` does not work anymore in `testcafe` versions > 0.21.1 when invoked like this:

```sh
testcafe-live chrome tests/
```
or

```sh
testcafe-live chrome tests/**/*.js
```

where `tests/**/*.js` should resolve to `tests/dir1/dir2/.../dirN/mytest.js`

Proposed solution:
pre-resolve paths using [https://github.com/sindresorhus/globby](https://github.com/sindresorhus/globby)
